### PR TITLE
A workaround fix for comment

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Launch Chrome against localhost",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}"
+    }
+  ]
+}

--- a/src/theme/DocItem/Paginator/index.tsx
+++ b/src/theme/DocItem/Paginator/index.tsx
@@ -9,6 +9,9 @@ type Props = WrapperProps<typeof PaginatorType>;
 
 export default function PaginatorWrapper(props: Props): JSX.Element {
   const { colorMode } = useColorMode();
+  // 02/03/2023: so far only mapping with url and path works.
+  // mapping with title has the problem of somehow using the title from the
+  // previous page.
   return (
     <>
       <Paginator {...props} />
@@ -18,7 +21,7 @@ export default function PaginatorWrapper(props: Props): JSX.Element {
         repoId="R_kgDOIzvQtQ"
         category="评论区"
         categoryId="DIC_kwDOIzvQtc4CT-SP"
-        mapping="title"
+        mapping="url"
         strict="0"
         reactionsEnabled="1"
         emitMetadata="1"


### PR DESCRIPTION
Seems like either docusaurus or giscus have a bug: it gets previous page's title etc.